### PR TITLE
Fix configuration bugs and update Docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/deployment.md
+++ b/deployment.md
@@ -36,7 +36,7 @@ cd news.docms.nz
 
 **Dockerfile**:
 ```dockerfile
-FROM python:3.13-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- ensure news folder path is configurable and exists
- provide default admin credentials
- clean up file rename logic
- switch Docker base image to Python 3.11
- update deployment docs accordingly

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851ac21a070832c809203b627e66215